### PR TITLE
Fixed --expires so that it honors the command line option

### DIFF
--- a/lib/principal.js
+++ b/lib/principal.js
@@ -14,12 +14,12 @@ var accessToken = function(callback) {
         cli.globals.startSession(function(err, session, user) {
             if (err) return callback(err);
 
-            var expires;
+            var expires = new Date(2050,0,1).getTime();
             if (cli.flags.expires)
                 expires = Date.parse(cli.flags.expires);
 
             nitrogen.Principal.accessTokenFor(session, principalId, {
-                expires: new Date(2050,0,1).getTime()
+                expires: expires
             }, function(err, accessToken) {
                 if (err) return callback(err);
 


### PR DESCRIPTION
This fixes what the CLI is doing for accesstoken expiration *but* it doesn't seem to fix the one day timeout problem (which might be related to this:

   accessToken.token = jwt.sign({
        iss: principal.id
    }, core.config.access_token_signing_key, { expiresInMinutes: 60 * 24 * core.config.access_token_lifetime });
)

Found here: https://github.com/nitrogenjs/core/blob/master/lib/services/accessTokens.js